### PR TITLE
Added threejs as a package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "three": "^0.73.0",
     "three-orbit-controls": "^72.0.0",
     "webpack": "^1.12.2"
+  },
+  "dependencies": {
+    "three": "^0.114.0"
   }
 }


### PR DESCRIPTION
By having three as a package dependency, we don't have the issue of compilation failures when used in the babel toolchain along and where three is used as an es6 module and not as a HTML import.